### PR TITLE
Feature/dispatcher auth checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Manages an AEM CRX Package; allows for saving packages via a file (in the crx-qu
 Namevar. Required.
 
 ##### `ensure`
-Required. Changes the state of this CRX Package.  
+Required. Changes the state of this CRX Package.
 * `present`: Uploaded but not installed; if installed will uninstall.
 * `installed`: Uploaded and installed; Equivalent to `present` when **type** == `file`. (**Default**)
 * `purged`: Uninstalled, then removed from the package manager. Equivalent to `absent` when **type** == `file`.
@@ -647,6 +647,26 @@ Optional. Sets the cache */allowedClients* section. Valid options: Hash, or Arra
 {
   'type' => 'allow',
   'glob' => '*',
+}
+~~~
+
+##### `auth_checker`
+Optional. Sets the */auth_checker* section. Valid options: Hash. Example
+~~~ puppet
+{
+  url => '/bin/permissioncheck',
+  filter => [
+    {
+      'type' => 'allow',
+      'glob' => '*',
+    }
+  ],
+  headers => [
+    {
+      'type' => 'allow',
+      'glob' => '*',
+    }
+  ],
 }
 ~~~
 

--- a/docs/AEM-Dispatcher-Farm.md
+++ b/docs/AEM-Dispatcher-Farm.md
@@ -13,6 +13,7 @@ The `aem::dispatcher::farm` resource allows you to configure a Dispatcher Farm d
 * [Vanity URLs](dispatcher/Vanity-URLs.md)
 * [Propagate Synd Post](dispatcher/Propagate-Synd-Post.md)
 * [Cache Rules](dispatcher/Cache-Rules.md)
+* [Permission-sensitive caching](dispatcher/Permission-sensitive-Caching.md)
 * [Statistics](dispatcher/Statistics.md)
 * [Unavailability Penalty](dispatcher/Unavailability-Penalty.md)
 * [Sticky Connections](dispatcher/Sticky-Connections.md)

--- a/docs/dispatcher/Permission-sensitive-Caching.md
+++ b/docs/dispatcher/Permission-sensitive-Caching.md
@@ -1,0 +1,94 @@
+# Dispatcher
+
+## Permission-sensitive caching
+
+[See Documentation](https://helpx.adobe.com/experience-manager/dispatcher/using/permissions-cache.html)
+
+This example creates a Farm definition that performs permission checks only on secure HTML resources:
+
+~~~ puppet
+aem::dispatcher::farm { 'site' :
+  docroot        => '/var/www',
+  auth_checker => {
+    url => '/bin/permissioncheck',
+    filter => [
+      {
+        'type' => 'deny',
+        'glob' => '*',
+      },
+      {
+        'type' => 'allow',
+        'glob' => '/content/secure/*.html',
+      }
+    ],
+    headers => [
+      {
+        'type' => 'deny',
+        'glob' => '*',
+      },
+      {
+        'type' => 'allow',
+        'glob' => 'Set-Cookie:*',
+      }
+    ],
+  },
+}
+~~~
+
+This definition will create a file *dispatcher.site.any* with the following contents:
+
+~~~
+/anothersite {
+
+  /clientheaders {
+    "*"
+  }
+
+  /virtualhosts {
+    "*"
+  }
+
+  /renders {
+    /renderer0 {
+      /hostname "localhost"
+      /port "4503"
+    }
+  }
+
+  /filter {
+    /0 { /type "allow" /glob "*" }
+  }
+
+  /cache {
+
+    /docroot "/var/www"
+
+    /rules {
+      /0 { /type "deny" /glob "*" }
+    }
+
+    /invalidate {
+      /0 { /type "allow" /glob "*" }
+    }
+
+    /allowedClients {
+      /0 { /type "allow" /glob "*" }
+    }
+  }
+
+  /auth_checker {
+
+    /url "/bin/permissioncheck"
+
+    /filter {
+      /0 { /type "deny" /glob "*" }
+      /1 { /type "allow" /glob "/content/secure/*.html" }
+    }
+
+    /headers {
+      /0 { /type "deny" /glob "*" }
+      /1 { /type "allow" /glob "Set-Cookie:*" }
+    }
+  }
+}
+~~~

--- a/manifests/dispatcher/farm.pp
+++ b/manifests/dispatcher/farm.pp
@@ -5,6 +5,7 @@ define aem::dispatcher::farm(
   $ensure              = 'present',
   $allow_authorized    = undef,
   $allowed_clients     = $::aem::dispatcher::params::allowed_clients,
+  $auth_checker        = undef,
   $cache_headers       = undef,
   $cache_rules         = $::aem::dispatcher::params::cache_rules,
   $cache_ttl           = undef,
@@ -50,6 +51,32 @@ define aem::dispatcher::farm(
   } else {
     validate_hash($allowed_clients)
     $_allowed_clients = [$allowed_clients]
+  }
+
+  if $auth_checker {
+    validate_hash($auth_checker)
+
+    if !has_key($auth_checker, 'url') {
+      fail('Auth checker url is not specified.')
+    }
+
+    if !has_key($auth_checker, 'filter') {
+      fail('Auth checker filter are not specified.')
+    } else {
+      if !is_array($auth_checker['filter']) {
+        fail('Auth checker filter must be an array.')
+      }
+      validate_hash($auth_checker['filter'][0])
+    }
+
+    if !has_key($auth_checker, 'headers') {
+      fail('Auth checker headers are not specified.')
+    } else {
+      if !is_array($auth_checker['headers']) {
+        fail('Auth checker headers must be an array.')
+      }
+      validate_hash($auth_checker['headers'][0])
+    }
   }
 
   if $cache_headers {

--- a/spec/defines/dispatcher/farm/params_spec.rb
+++ b/spec/defines/dispatcher/farm/params_spec.rb
@@ -172,6 +172,122 @@ describe 'aem::dispatcher::farm', type: :define do
       end
     end
 
+    context 'auth_checker' do
+      context 'should compile' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'filter' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ],
+              'headers' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ]
+            }
+          )
+        end
+        it { is_expected.to compile.with_all_deps }
+      end
+      context 'should require a url' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'filter' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ],
+              'headers' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ]
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/.*url is not specified./) }
+      end
+      context 'should require a filter element' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'headers' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ]
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/.*filter are not specified./) }
+      end
+      context 'should require the filter element to be an array' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'filter' => { 'type' => 'deny', 'glob' => '*' },
+              'headers' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ]
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/.*must be an array./) }
+      end
+      context 'should require the filter element to be an array of hashes' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'filter' => ['not a hash', 'another non hash'],
+              'headers' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ]
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/not a hash/i) }
+      end
+      context 'should require a headers element' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'filter' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ]
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/.*headers are not specified./) }
+      end
+      context 'should require the headers element to be an array' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'filter' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ],
+              'headers' => { 'type' => 'deny', 'glob' => '*' }
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/.*must be an array./) }
+      end
+      context 'should require the headers element to be an array of hashes' do
+        let(:params) do
+          default_params.merge(
+            auth_checker: {
+              'url' => '/bin/permissioncheck',
+              'filter' => [
+                { 'type' => 'deny', 'glob' => '*' }
+              ],
+              'headers' => ['not a hash', 'another non hash']
+            }
+          )
+        end
+        it { expect { is_expected.to compile }.to raise_error(/not a hash/i) }
+      end
+    end
+
     context 'cache_ttl' do
       context 'should accept 0' do
         let(:params) do

--- a/spec/defines/dispatcher/farm/template_spec.rb
+++ b/spec/defines/dispatcher/farm/template_spec.rb
@@ -57,6 +57,8 @@ describe 'aem::dispatcher::farm', type: :define do
       ).without_content(
         /gracePeriod/
       ).without_content(
+        /auth_checker/
+      ).without_content(
         %r|/headers|
       ).without_content(
         /failover/
@@ -174,6 +176,40 @@ describe 'aem::dispatcher::farm', type: :define do
           '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
         ).with_content(
           %r|/enableTTL "1"\s*|
+        )
+      end
+    end
+
+    context 'auth_checker' do
+      let(:params) do
+        default_params.merge(
+          auth_checker: {
+            'url'     => '/bin/permissioncheck',
+            'filter'  => [
+              { 'type' => 'deny', 'glob' => '*' }
+            ],
+            'headers' => [
+              { 'type' => 'deny', 'glob' => '*' }
+            ]
+          }
+        )
+      end
+      it { is_expected.to compile }
+      it do
+        is_expected.to contain_file(
+          '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+        ).with_content(
+          %r|
+            /auth_checker\s{\s*
+              /url\s"/bin/permissioncheck"\s*
+              /filter\s{\s*
+                /0\s{\s/type\s"deny"\s/glob\s"\*"\s}\s*
+              }\s*
+              /headers\s{\s*
+                /0\s{\s/type\s"deny"\s/glob\s"\*"\s}\s*
+              }\s*
+            }
+          |x
         )
       end
     end

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -169,7 +169,7 @@
     /url "<%= @auth_checker['url'] -%>"
 
     /filter {
-    <%- @auth_checker['filters'].sort_by { |entry| entry['rank'] || -1 }.each_with_index do |filter, idx| -%>
+    <%- @auth_checker['filter'].sort_by { |entry| entry['rank'] || -1 }.each_with_index do |filter, idx| -%>
       <%- if filter['glob'] -%>
       /<%= idx -%> { /type "<%= filter['type'] -%>" /glob "<%= filter['glob'] -%>" }
       <%- else -%>
@@ -206,7 +206,7 @@
 
     /headers {
     <%- @auth_checker['headers'].sort_by { |entry| entry['rank'] || -1 }.each_with_index do |header, idx| -%>
-      /<%= idx -%> { /type "<%= rule['type'] -%>" /glob "<%= rule['glob'] -%>" }
+      /<%= idx -%> { /type "<%= header['type'] -%>" /glob "<%= header['glob'] -%>" }
     <%- end -%>
     }
   }

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -33,7 +33,7 @@
 
   /renders {
   <%- @_renders.each_with_index do |renderer, idx| -%>
-    /renderer<%= idx -%> { 
+    /renderer<%= idx -%> {
       /hostname "<%= renderer['hostname'] -%>"
       /port "<%= renderer['port'] -%>"
       <%- if renderer['timeout'] -%>
@@ -162,6 +162,55 @@
     /enableTTL "<%= @cache_ttl-%>"
     <%- end -%>
   }
+
+  <%- if @auth_checker -%>
+  /auth_checker {
+
+    /url "<%= @auth_checker['url'] -%>"
+
+    /filter {
+    <%- @auth_checker['filters'].sort_by { |entry| entry['rank'] || -1 }.each_with_index do |filter, idx| -%>
+      <%- if filter['glob'] -%>
+      /<%= idx -%> { /type "<%= filter['type'] -%>" /glob "<%= filter['glob'] -%>" }
+      <%- else -%>
+      /<%= idx -%> {
+        /type "<%= filter['type'] -%>"
+        <%- if filter['method'] -%>
+        /method "<%= filter['method'] -%>"
+        <%- end -%>
+        <%- if filter['url'] -%>
+        /url "<%= filter['url'] -%>"
+        <%- end -%>
+        <%- if filter['query'] -%>
+        /query "<%= filter['query'] -%>"
+        <%- end -%>
+        <%- if filter['protocol'] -%>
+        /protocol "<%= filter['protocol'] -%>"
+        <%- end -%>
+        <%- if filter['path'] -%>
+        /path "<%= filter['path'] -%>"
+        <%- end -%>
+        <%- if filter['selectors'] -%>
+        /selectors '<%= filter['selectors'] -%>'
+        <%- end -%>
+        <%- if filter['extension'] -%>
+        /extension '<%= filter['extension'] -%>'
+        <%- end -%>
+        <%- if filter['suffix'] -%>
+        /suffix '<%= filter['suffix'] -%>'
+        <%- end -%>
+      }
+      <%- end -%>
+    <%- end -%>
+    }
+
+    /headers {
+    <%- @auth_checker['headers'].sort_by { |entry| entry['rank'] || -1 }.each_with_index do |header, idx| -%>
+      /<%= idx -%> { /type "<%= rule['type'] -%>" /glob "<%= rule['glob'] -%>" }
+    <%- end -%>
+    }
+  }
+  <%-end -%>
 
   <%- if @_statistics -%>
   /statistics {

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -170,37 +170,7 @@
 
     /filter {
     <%- @auth_checker['filter'].sort_by { |entry| entry['rank'] || -1 }.each_with_index do |filter, idx| -%>
-      <%- if filter['glob'] -%>
       /<%= idx -%> { /type "<%= filter['type'] -%>" /glob "<%= filter['glob'] -%>" }
-      <%- else -%>
-      /<%= idx -%> {
-        /type "<%= filter['type'] -%>"
-        <%- if filter['method'] -%>
-        /method "<%= filter['method'] -%>"
-        <%- end -%>
-        <%- if filter['url'] -%>
-        /url "<%= filter['url'] -%>"
-        <%- end -%>
-        <%- if filter['query'] -%>
-        /query "<%= filter['query'] -%>"
-        <%- end -%>
-        <%- if filter['protocol'] -%>
-        /protocol "<%= filter['protocol'] -%>"
-        <%- end -%>
-        <%- if filter['path'] -%>
-        /path "<%= filter['path'] -%>"
-        <%- end -%>
-        <%- if filter['selectors'] -%>
-        /selectors '<%= filter['selectors'] -%>'
-        <%- end -%>
-        <%- if filter['extension'] -%>
-        /extension '<%= filter['extension'] -%>'
-        <%- end -%>
-        <%- if filter['suffix'] -%>
-        /suffix '<%= filter['suffix'] -%>'
-        <%- end -%>
-      }
-      <%- end -%>
     <%- end -%>
     }
 


### PR DESCRIPTION
Fixes #111

Extended the dispatcher config templating with the auth_checker option. Currently since this config only makes sense when properly configured, no defaults have been implemented.

Tests and documentation for the new config options are included.