### PR TITLE
Feature/dispatcher secure renders

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   Exclude:
     - 'pkg/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.2
 
 Metrics/BlockLength:
   Exclude:

--- a/docs/dispatcher/Renders.md
+++ b/docs/dispatcher/Renders.md
@@ -22,6 +22,7 @@ aem::dispatcher::farm { 'site' :
     'timeout'        => 600,
     'receiveTimeout' => 300,
     'ipv4'           => 0,
+    'secure'         => 0,
   },
 }
 ~~~
@@ -46,6 +47,7 @@ This definition will create a file *dispatcher.site.any* with the following cont
       /timeout "600"
       /receiveTimeout "300"
       /ipv4 "0"
+      /secure "0"
     }
   }
 
@@ -86,6 +88,7 @@ aem::dispatcher::farm { 'site' :
       'timeout'        => 600,
       'receiveTimeout' => 300,
       'ipv4'           => 0,
+      'secure'         => 0,
     },
     {
       'hostname' => 'author.hostname.com',
@@ -111,13 +114,15 @@ This definition will create a file *dispatcher.site.any* with the following cont
   /renders {
     /renderer0 { 
       /hostname "publish.hostname.com"
-      /port "9009"
-      /timeout "300"
-      /receiveTimeout "100"
+      /port "8080"
+      /timeout "600"
+      /receiveTimeout "300"
+      /ipv4 "0"
+      /secure "0"
     }
     /renderer1 { 
       /hostname "author.hostname.com"
-      /port "8080"
+      /port "9009"
     }
   }
 

--- a/spec/defines/dispatcher/farm/template_spec.rb
+++ b/spec/defines/dispatcher/farm/template_spec.rb
@@ -498,7 +498,9 @@ describe 'aem::dispatcher::farm', type: :define do
               'port'           => 8080,
               'timeout'        => 600,
               'receiveTimeout' => 300,
-              'ipv4'           => 0
+              'ipv4'           => 0,
+              'secure'         => 0
+
             }
           )
         end
@@ -515,6 +517,7 @@ describe 'aem::dispatcher::farm', type: :define do
                   /timeout\s*"600"\s*
                   /receiveTimeout\s*"300"\s*
                   /ipv4\s"0"\s*
+                  /secure\s"0"\s*
                 }\s*
               }
             |x
@@ -583,6 +586,25 @@ describe 'aem::dispatcher::farm', type: :define do
             '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
           ).with_content(
             %r|/renders {\s*/renderer0 {\s*/hostname\s*"publish.hostname.com"\s*/port\s"8080"\s*/ipv4\s*"0"\s*}|
+          )
+        end
+      end
+      context 'secure' do
+        let(:params) do
+          default_params.merge(
+            renders: {
+              'hostname' => 'publish.hostname.com',
+              'port'     => 8080,
+              'secure'   => 0
+            }
+          )
+        end
+        it { is_expected.to compile }
+        it do
+          is_expected.to contain_file(
+            '/etc/httpd/conf.modules.d/dispatcher.00-aem-site.inc.any'
+          ).with_content(
+            %r|/renders {\s*/renderer0 {\s*/hostname\s*"publish.hostname.com"\s*/port\s"8080"\s*/secure\s*"0"\s*}|
           )
         end
       end

--- a/templates/dispatcher/dispatcher.any.erb
+++ b/templates/dispatcher/dispatcher.any.erb
@@ -45,6 +45,9 @@
       <%- if renderer['ipv4'] -%>
       /ipv4 "<%= renderer['ipv4'] -%>"
       <%- end -%>
+      <%- if renderer['secure'] -%>
+      /secure "<%= renderer['secure'] -%>"
+      <%- end -%>
     }
   <%- end -%>
   }


### PR DESCRIPTION
Fixes #116

Added the secure option to the renders section of the dispatcher config template with. Currently since this config only makes sense when properly configured, no defaults have been implemented.

Tests and documentation for the new config options are included.

Also (hopefully) fixed an error thrown by rubocop:
Unsupported Ruby version 2.0 found in TargetRubyVersion parameter (in .rubocop.yml)