### PR TITLE
Fix puppet taking ages on hosts with large AEM repository

### DIFF
--- a/lib/puppet/provider/aem_installer/default.rb
+++ b/lib/puppet/provider/aem_installer/default.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:aem_installer).provide :default, parent: Puppet::Provider do
   def find_instance
     hash = {}
     begin
-      cmd = [command(:find).to_s, @resource[:home], "-name \"#{@launchpad_name}\"", '-type f']
+      cmd = [command(:find).to_s, @resource[:home], "-not \\( -path \"*/crx-quickstart/repository/*\" -prune \\) -name \"#{@launchpad_name}\"", '-type f']
       execpipe(cmd) do |process|
         process.each_line do |line|
           hash = found_to_hash(line)


### PR DESCRIPTION
During its run the AEM module searches the installation folder for a
already present crx-quickstart jar.

On hosts with a grown AEM instance the 'crx-quickstart/repository'
folder can become quite huge, causing the find call to take ages when
searching withing this folder.

To fix this issue the find call was modified to skip the folder
'crx-quickstart/repository'.

Fixes [#124]