### PR TITLE
Enable to load crx-quickstart/bin*_env.sh scripts into the context of…

### DIFF
--- a/templates/start-env.erb
+++ b/templates/start-env.erb
@@ -6,6 +6,7 @@
 #
 # This file manages the configuration of the run script.
 #
+BIN_PATH=$(dirname $0)
 
 TYPE='<%= @type %>'
 PORT=<%= @port %>
@@ -30,3 +31,16 @@ SLING_PROPS='conf/sling.properties'
 
 # This doesn't ever seem to work
 #LOG_LEVEL=
+
+
+# add the possibility to load additional env context 
+# from the bin folder that only will be valid for the aem-process 
+for i in $BIN_PATH/*_env.sh  ; do
+    if [ -r "$i" ]; then
+        if [ "${-#*i}" != "$-" ]; then
+            . "$i"
+        else
+            . "$i" >/dev/null
+        fi
+    fi
+done


### PR DESCRIPTION
Enable us to load 

> crx-quickstart/bin*_env.sh 

scripts into the context of the aem-process

This can be useful if to e.g. load environment vars for 3rd party tools that are supposed to be used by aem or set some other specific params without changing the codebase